### PR TITLE
1.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>nl.aerius</groupId>
   <artifactId>search-parent</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <packaging>pom</packaging>
   <name>AERIUS Search</name>
   <url>https://www.aerius.nl</url>

--- a/search-client/pom.xml
+++ b/search-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>search-parent</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
   </parent>
 
   <artifactId>search-client</artifactId>

--- a/search-client/src/main/java/nl/aerius/search/wui/component/MapSearchComponent.html
+++ b/search-client/src/main/java/nl/aerius/search/wui/component/MapSearchComponent.html
@@ -2,7 +2,7 @@
 <vue-gwt:import class="java.util.Collection" />
 <vue-gwt:import class="nl.aerius.search.wui.domain.SearchSuggestion" />
 
-<div class="searchContainer">
+<div class="searchInputContainer">
   <input v-model="search"
     type="text"
     ref="input"
@@ -83,7 +83,7 @@
   margin: 0px 10px;
 }
 
-.searchContainer {
+.searchInputContainer {
   display: flex;
 }
 
@@ -92,7 +92,7 @@
   padding: 4px 10px;
   width: 100%;
   z-index: 1;
-  height: var(--height);
+  height: var(--search-height);
 }
 
 .noResultsContainer {
@@ -110,7 +110,7 @@
 
 .resultsContainer, .noResultsContainer {
   background: white;
-  top: var(--height);
+  top: var(--search-height);
   width: 100%;
   max-width: 100vw;
 

--- a/search-client/src/main/java/nl/aerius/search/wui/component/PopoutSearchComponent.html
+++ b/search-client/src/main/java/nl/aerius/search/wui/component/PopoutSearchComponent.html
@@ -76,6 +76,7 @@
 .searchPopout {
   z-index: 1;
   position: absolute;
+  top: 0px;
   width: var(--search-width);
   right: calc(60px);
   

--- a/search-service-extension/pom.xml
+++ b/search-service-extension/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>search-parent</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
   </parent>
 
   <artifactId>search-service-extension</artifactId>

--- a/search-service-geo/pom.xml
+++ b/search-service-geo/pom.xml
@@ -26,7 +26,7 @@
   </parent>
   <groupId>nl.aerius</groupId>
   <artifactId>search-service-geo</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <name>AERIUS Search :: Service Geo Capabilities</name>
 
   <properties>

--- a/search-service-mocks/pom.xml
+++ b/search-service-mocks/pom.xml
@@ -27,7 +27,7 @@
   </parent>
   <groupId>nl.aerius</groupId>
   <artifactId>search-service-mocks</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <name>AERIUS Search :: Service Mocks</name>
 
   <properties>

--- a/search-service-n2000-assessment-areas-nl/pom.xml
+++ b/search-service-n2000-assessment-areas-nl/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>nl.aerius</groupId>
   <artifactId>search-service-n2000-assessment-areas-nl</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <name>AERIUS Search :: Service Natura 2000 areas NL</name>
 
   <properties>

--- a/search-service-pdok-locatieservice/pom.xml
+++ b/search-service-pdok-locatieservice/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>nl.aerius</groupId>
   <artifactId>search-service-pdok-locatieservice</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <name>AERIUS Search :: Service PDOK Locatieservice wrapper</name>
 
   <properties>

--- a/search-service/pom.xml
+++ b/search-service/pom.xml
@@ -27,7 +27,7 @@
   </parent>
   <groupId>nl.aerius</groupId>
   <artifactId>search-service</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <name>AERIUS Search :: Service</name>
 
   <properties>

--- a/search-shared/pom.xml
+++ b/search-shared/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>search-parent</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
   </parent>
 
   <artifactId>search-shared</artifactId>

--- a/search-sonar-report/pom.xml
+++ b/search-sonar-report/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>search-parent</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
   </parent>
 
   <artifactId>search-sonar-report</artifactId>


### PR DESCRIPTION
- Don't let classnames conflict
- Move to `--search-height` rather than the too generic `--height`
- Set top to 0 for search popout
