### PR TITLE
Fix map search popup throws error bug

### DIFF
--- a/search-client/src/main/java/nl/aerius/search/wui/component/MapSearchComponent.java
+++ b/search-client/src/main/java/nl/aerius/search/wui/component/MapSearchComponent.java
@@ -99,15 +99,17 @@ public class MapSearchComponent implements IsVueComponent, HasCreated, HasMounte
   @JsMethod
   public String highlight(final String plain) {
     String result = plain;
-    final String[] split = search.split(" ");
-    for (int i = 0; i < split.length; i++) {
-      final String sample = split[i];
-      if (sample.isEmpty()
-          || BOLD_CHARACTER.equals(sample.toLowerCase())) {
-        continue;
-      }
+    if (hasQuery()) {
+      final String[] split = search.split(" ");
+      for (int i = 0; i < split.length; i++) {
+        final String sample = split[i];
+        if (sample.isEmpty()
+            || BOLD_CHARACTER.equals(sample.toLowerCase())) {
+          continue;
+        }
 
-      result = boldenText(result, sample);
+        result = boldenText(result, sample);
+      }
     }
     return result;
   }


### PR DESCRIPTION
This fixes the bug where an exception was thrown by the search popup.
Reproduce:
1) Open calculator
2) Open search, search for something, select to show on map.
3) Create a new source
4) Go to calculate page
5) Go back to sources page
6) Error in notification panel