### PR TITLE
Use new gwt-client-common-bom to import versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <imaer.version>4.0.2-2</imaer.version>
     <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
 
-    <aerius.gwt-client-common.version>1.2.1</aerius.gwt-client-common.version>
+    <aerius.gwt-client-common.version>1.5.0-SNAPSHOT</aerius.gwt-client-common.version>
     <aerius.gwt-client-common-json.version>1.3.0</aerius.gwt-client-common-json.version>
     <jacoco.version>0.8.7</jacoco.version>
 
@@ -89,21 +89,10 @@
     <dependencies>
       <dependency>
         <groupId>nl.aerius</groupId>
-        <artifactId>gwt-client-vue</artifactId>
+        <artifactId>gwt-client-common-bom</artifactId>
         <version>${aerius.gwt-client-common.version}</version>
-        <type>gwt-lib</type>
-      </dependency>
-      <dependency>
-        <groupId>nl.aerius</groupId>
-        <artifactId>gwt-client-common</artifactId>
-        <version>${aerius.gwt-client-common.version}</version>
-        <type>gwt-lib</type>
-      </dependency>
-      <dependency>
-        <groupId>nl.aerius</groupId>
-        <artifactId>gwt-client-common-json</artifactId>
-        <version>${aerius.gwt-client-common-json.version}</version>
-        <type>gwt-lib</type>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <plugin>
           <groupId>net.ltgt.gwt.maven</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
-          <version>1.0.0</version>
+          <version>1.0.1</version>
           <extensions>true</extensions>
           <configuration>
             <sourceLevel>${maven.compiler.source}</sourceLevel>

--- a/search-client/pom.xml
+++ b/search-client/pom.xml
@@ -30,18 +30,10 @@
   <packaging>gwt-lib</packaging>
 
   <properties>
-    <com.google.gwt.version>2.8.2</com.google.gwt.version>
     <vue.version>1.0.1</vue.version>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>com.google.gwt</groupId>
-      <artifactId>gwt-user</artifactId>
-      <scope>provided</scope>
-      <version>${com.google.gwt.version}</version>
-    </dependency>
-
     <dependency>
       <groupId>com.axellience</groupId>
       <artifactId>vue-gwt</artifactId>
@@ -74,12 +66,6 @@
       <artifactId>search-shared</artifactId>
       <version>${project.version}</version>
       <type>gwt-lib</type>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.elemental2</groupId>
-      <artifactId>elemental2-dom</artifactId>
-      <version>1.0.0-RC1</version>
     </dependency>
   </dependencies>
 

--- a/search-client/pom.xml
+++ b/search-client/pom.xml
@@ -29,23 +29,7 @@
 
   <packaging>gwt-lib</packaging>
 
-  <properties>
-    <vue.version>1.0.1</vue.version>
-  </properties>
-
   <dependencies>
-    <dependency>
-      <groupId>com.axellience</groupId>
-      <artifactId>vue-gwt</artifactId>
-      <version>${vue.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.axellience</groupId>
-      <artifactId>vue-gwt-processors</artifactId>
-      <version>${vue.version}</version>
-      <optional>true</optional>
-    </dependency>
-
     <dependency>
       <groupId>nl.aerius</groupId>
       <artifactId>gwt-client-vue</artifactId>


### PR DESCRIPTION
Remove direct dependencies on GWT projects; use inherited version from gwt-client-common to make sure the same versions are used.