### PR TITLE
[TERRAFORM] Added a default value for ssm password

### DIFF
--- a/terraform/application_services/app.hcl
+++ b/terraform/application_services/app.hcl
@@ -14,6 +14,8 @@ locals {
     "rule1"    = {tg = "tg1", application_type = "SEARCH", path_pattern = "/*", cognito = true}
   }
 
+  ssm_passwords = {}
+
   ecs_ctr_fes_1_max_instance_size     = "2"
 
   ecs_capacity_providers = {


### PR DESCRIPTION
SSM passwords It's expects a value, even if it's not used. So we provided a default empty list.