### PR TITLE
[TERRAFORM] Updated name config

### DIFF
--- a/terraform/application_services/ecs_services/service_configuration/services.yaml.tftpl
+++ b/terraform/application_services/ecs_services/service_configuration/services.yaml.tftpl
@@ -17,8 +17,8 @@
 
 services:
 
-  search:
-    image: ${REGISTRY_URL}/search:${APP_VERSION}
+  service:
+    image: ${REGISTRY_URL}/service:${APP_VERSION}
     cpu: 4096
     memory: 8192
     desired_count: 1


### PR DESCRIPTION
Updated the name from `search` to `service` in the Terraform config to match the naming convention used with Docker.