### PR TITLE
[TERRAFORM] Changes in memory and default instance size

### DIFF
--- a/terraform/application_services/app.hcl
+++ b/terraform/application_services/app.hcl
@@ -16,6 +16,7 @@ locals {
 
   ssm_passwords = {}
 
+  ecs_ctr_fes_1_instance_type         = "c5.xlarge"
   ecs_ctr_fes_1_max_instance_size     = "2"
 
   ecs_capacity_providers = {

--- a/terraform/application_services/ecs_services/service_configuration/services.yaml.tftpl
+++ b/terraform/application_services/ecs_services/service_configuration/services.yaml.tftpl
@@ -20,7 +20,7 @@ services:
   service:
     image: ${REGISTRY_URL}/service:${APP_VERSION}
     cpu: 4096
-    memory: 8192
+    memory: 7100
     desired_count: 1
     target_group: tg1
     portmappings:


### PR DESCRIPTION
Changed the default instance size within the application repo. 
Every version of search will use the configured instance size within the `app.hcl`, except when it's overwritten by the Cloud deployment.