### PR TITLE
AER-2539 Add delay to searching

### DIFF
--- a/search-client/src/main/java/nl/aerius/search/wui/daemon/SearchDaemonAsynchronous.java
+++ b/search-client/src/main/java/nl/aerius/search/wui/daemon/SearchDaemonAsynchronous.java
@@ -68,7 +68,7 @@ public class SearchDaemonAsynchronous extends BasicEventComponent {
 
   interface SearchDaemonAsynchronousEventBinder extends EventBinder<SearchDaemonAsynchronous> {}
 
-  private static final int START_SEARCH_DELAY = 1000;
+  private static final int START_SEARCH_DELAY = 500;
   private static final int DELAY = 250;
 
   @Inject SearchContext context;


### PR DESCRIPTION
This should prevent flooding the service when the user is just typing at a normal pace until he pauses to think. Sure, google also sends a request for each keystroke, but google also does not use an async process and has multiple servers running.