### PR TITLE
AER-2539 error handling in service

### DIFF
--- a/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/BingSearchService.java
+++ b/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/BingSearchService.java
@@ -137,10 +137,10 @@ public class BingSearchService implements SearchTaskService {
           Thread.currentThread().interrupt();
         }
       } else {
-        throw new RuntimeException("Unexpected status code: " + statusCode);
+        throw new BingServiceException("Unexpected status code: " + statusCode);
       }
     }
-    throw new RuntimeException("Retries failed, last returned: " + body);
+    throw new BingServiceException("Retries failed, last returned: " + body);
   }
 
   private SuggestedLocation createSuggestedLocation(final JSONObject jsonObject) {

--- a/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/BingSearchService.java
+++ b/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/BingSearchService.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -76,6 +77,7 @@ public class BingSearchService implements SearchTaskService {
    * https://docs.microsoft.com/en-us/bingmaps/getting-started/bing-maps-api-best-practices#reducing-usage-transactions
    */
   @Value("${nl.aerius.bing.apiKey:#{null}}") private String apiKey;
+  @Value("${nl.aerius.bing.maxRetries:3}") private int maxRetries;
 
   @Override
   public Single<SearchTaskResult> retrieveSearchResults(final String query) {
@@ -119,9 +121,26 @@ public class BingSearchService implements SearchTaskService {
   }
 
   private JSONArray obtainResources(final String url) {
-    final HttpResponse<JsonNode> json = Unirest.get(url).asJson();
-    final JSONObject body = json.getBody().getObject();
-    return body.getJSONArray("resourceSets").getJSONObject(0).getJSONArray("resources");
+    JSONObject body = null;
+    int retry = 0;
+    while (retry++ < maxRetries) {
+      final HttpResponse<JsonNode> json = Unirest.get(url).asJson();
+      body = json.getBody().getObject();
+      final int statusCode = body.getInt("statusCode");
+      if (statusCode == 200) {
+        return body.getJSONArray("resourceSets").getJSONObject(0).getJSONArray("resources");
+      } else if (statusCode == 429) {
+        LOG.info("Got too many retries status code from Bing, attempt {}.", retry);
+        try {
+          TimeUnit.SECONDS.sleep(1);
+        } catch (final InterruptedException ie) {
+          Thread.currentThread().interrupt();
+        }
+      } else {
+        throw new RuntimeException("Unexpected status code: " + statusCode);
+      }
+    }
+    throw new RuntimeException("Retries failed, last returned: " + body);
   }
 
   private SuggestedLocation createSuggestedLocation(final JSONObject jsonObject) {

--- a/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/BingServiceException.java
+++ b/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/BingServiceException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.search.tasks;
+
+public class BingServiceException extends RuntimeException {
+
+  public BingServiceException(final String message) {
+    super(message);
+  }
+}

--- a/search-service-bing-geocoder/src/test/java/nl/aerius/search/tasks/BingSearchServiceTest.java
+++ b/search-service-bing-geocoder/src/test/java/nl/aerius/search/tasks/BingSearchServiceTest.java
@@ -45,5 +45,11 @@ class BingSearchServiceTest {
     final SearchTaskResult suggestions = result.blockingGet();
 
     assertEquals(5, suggestions.getSuggestions().size(), "Expected number of results for 'edin' (should include 'edinburgh')");
+
+    final Single<SearchTaskResult> resultYork = delegator.retrieveSearchResults("york");
+
+    final SearchTaskResult suggestionsYork = resultYork.blockingGet();
+
+    assertEquals(4, suggestionsYork.getSuggestions().size(), "Expected number of results for 'edin' (should include 'edinburgh')");
   }
 }

--- a/search-service-mocks/src/main/java/nl/aerius/search/tasks/MockRuntimeExceptionTask.java
+++ b/search-service-mocks/src/main/java/nl/aerius/search/tasks/MockRuntimeExceptionTask.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.search.tasks;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import io.reactivex.rxjava3.core.Single;
+
+import nl.aerius.search.domain.SearchCapability;
+import nl.aerius.search.domain.SearchTaskResult;
+
+@Component
+@ImplementsCapability(SearchCapability.MOCK_RUNTIME_EXCEPTION)
+public class MockRuntimeExceptionTask implements SearchTaskService {
+  private static final Logger LOG = LoggerFactory.getLogger(MockRuntimeExceptionTask.class);
+
+  @Override
+  public Single<SearchTaskResult> retrieveSearchResults(final String query) {
+    LOG.debug("Mocking runtim exception for query [{}]", query);
+    throw new NullPointerException("Some mocked nullpointer");
+  }
+}

--- a/search-service/src/main/java/nl/aerius/search/tasks/async/SearchResult.java
+++ b/search-service/src/main/java/nl/aerius/search/tasks/async/SearchResult.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import nl.aerius.search.domain.SearchSuggestion;
+import nl.aerius.search.domain.SearchSuggestionBuilder;
 import nl.aerius.search.domain.SearchTaskResult;
 
 public class SearchResult {
@@ -45,7 +46,16 @@ public class SearchResult {
     return complete;
   }
 
-  public void complete() {
+  public void failureComplete() {
+    if (LOG.isTraceEnabled()) {
+      LOG.error("Search task {} has completed with a failure.", uuid);
+    }
+    results.add(SearchSuggestionBuilder.create("Failure during search, please contact the helpdesk"));
+
+    complete = true;
+  }
+
+  public void fullyComplete() {
     if (LOG.isTraceEnabled()) {
       LOG.trace("Search task {} has fully completed.", uuid);
     }

--- a/search-service/src/main/java/nl/aerius/search/tasks/sync/BlockingSearchTaskDelegator.java
+++ b/search-service/src/main/java/nl/aerius/search/tasks/sync/BlockingSearchTaskDelegator.java
@@ -30,6 +30,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
 import nl.aerius.search.domain.SearchSuggestion;
+import nl.aerius.search.domain.SearchSuggestionBuilder;
 import nl.aerius.search.tasks.CapabilityKey;
 import nl.aerius.search.tasks.SearchTaskService;
 import nl.aerius.search.tasks.TaskFactory;
@@ -69,6 +70,10 @@ public class BlockingSearchTaskDelegator {
         .flatMap(v -> Flowable.fromIterable(v.getSuggestions()))
         .sorted(TaskUtils.getResultComparator())
         .toList()
+        .onErrorReturn(e -> {
+          LOG.error("General error while executing search task:", e);
+          return List.of(SearchSuggestionBuilder.create("Failure during search, please contact the helpdesk"));
+        })
         .blockingGet();
   }
 }

--- a/search-service/src/main/resources/templates/synchronous-form.html
+++ b/search-service/src/main/resources/templates/synchronous-form.html
@@ -47,6 +47,7 @@
         <div><input type="checkbox" id="MOCK_5" data-name="MOCK_5" onchange="toggleCapability(this)"><label for="MOCK_5">mock_5 (5 sec delayed mock result)</label></div>
         <div><input type="checkbox" id="MOCK_GROUP_0" data-name="MOCK_GROUP_0" onchange="toggleCapability(this)"><label for="MOCK_GROUP_0">mock_group_0 (0 sec delayed mock group result)</label></div>
         <div><input type="checkbox" id="MOCK_GROUP_1" data-name="MOCK_GROUP_1" onchange="toggleCapability(this)"><label for="MOCK_GROUP_1">mock_group_1 (1 sec delayed mock group result)</label></div>
+        <div><input type="checkbox" id="MOCK_RUNTIME_EXCEPTION" data-name="MOCK_RUNTIME_EXCEPTION" onchange="toggleCapability(this)"><label for="MOCK_RUNTIME_EXCEPTION">mock_runtime_exception (instant runtime exception during search)</label></div>
       </div>
 
       <input class="submit" type="submit" text="Submit">

--- a/search-shared/src/main/java/nl/aerius/search/domain/SearchCapability.java
+++ b/search-shared/src/main/java/nl/aerius/search/domain/SearchCapability.java
@@ -36,7 +36,9 @@ public enum SearchCapability {
   MOCK_5,
 
   MOCK_GROUP_0,
-  MOCK_GROUP_1;
+  MOCK_GROUP_1,
+
+  MOCK_RUNTIME_EXCEPTION;
 
   public static SearchCapability safeValueOf(final String name) {
     try {


### PR DESCRIPTION
* Retry-mechanism when Bing indicates that we've fired too many requests recently
* Better error handling in the RxJava part, at least completing a search task if there's a runtime exception we didn't think about.

 With this implementation runtime exceptions in a search service will cause the search task to return with a generic error message (and not wait for other running results). Another option would be to silently ignore it (well, log it, but who ever looks at the logs?).