### PR TITLE
AER-2434 Remove use of custom gwtvue library by using updated gwt-client-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,7 @@
     <imaer.version>5.1.0-2</imaer.version>
     <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
 
-    <aerius.gwt-client-common.version>1.6.1</aerius.gwt-client-common.version>
-    <aerius.gwt-client-common-json.version>1.3.0</aerius.gwt-client-common-json.version>
+    <aerius.gwt-client-common.version>1.8.0-SNAPSHOT</aerius.gwt-client-common.version>
     <jacoco.version>0.8.8</jacoco.version>
 
     <aerius.tools.version>1.2.0</aerius.tools.version>


### PR DESCRIPTION
Makes it possible to use with Java 17.