### PR TITLE
Made search for coordinate a bit more flexible

### DIFF
--- a/search-service-geo/src/main/java/nl/aerius/search/tasks/coordinate/AbstractCoordinateSearchService.java
+++ b/search-service-geo/src/main/java/nl/aerius/search/tasks/coordinate/AbstractCoordinateSearchService.java
@@ -39,7 +39,7 @@ public abstract class AbstractCoordinateSearchService implements SearchTaskServi
 
   // Regex used to identify a x:{x} y:{y} string
   private static final Pattern SEARCH_TERM_COORDINATE_REGEX = Pattern
-      .compile("(x:)(\\d{1,6}).(y:)(\\d{1,6})", Pattern.CASE_INSENSITIVE);
+      .compile("(x:)?(\\d{1,6}\\.?\\d{1,6}?).\\s*(y:)?(\\d{1,6}\\.?\\d{1,6}?)", Pattern.CASE_INSENSITIVE);
 
   // The relevant groups in the above regular expression that identify the X and Y
   // coordinates respectively.
@@ -57,9 +57,10 @@ public abstract class AbstractCoordinateSearchService implements SearchTaskServi
   @Override
   public Single<SearchTaskResult> retrieveSearchResults(final String query) {
     final Matcher coordinateMatch = SEARCH_TERM_COORDINATE_REGEX.matcher(query);
+
     if (coordinateMatch.matches()) {
-      final int x = Integer.parseInt(coordinateMatch.group(SEARCH_TERM_COORDINATE_REGEX_GROUP_X));
-      final int y = Integer.parseInt(coordinateMatch.group(SEARCH_TERM_COORDINATE_REGEX_GROUP_Y));
+      final int x = (int) Math.round(Double.parseDouble(coordinateMatch.group(SEARCH_TERM_COORDINATE_REGEX_GROUP_X)));
+      final int y = (int) Math.round(Double.parseDouble(coordinateMatch.group(SEARCH_TERM_COORDINATE_REGEX_GROUP_Y)));
 
       final Point point = new Point(x, y);
       final int recId = util.getReceptorIdFromPoint(point);

--- a/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/RDNewCoordinateSearchServiceTest.java
+++ b/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/RDNewCoordinateSearchServiceTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.reactivex.rxjava3.core.Single;
 
@@ -36,9 +38,10 @@ class RDNewCoordinateSearchServiceTest {
     service = new RDNewCoordinateSearchService();
   }
 
-  @Test
-  void testCoordinateNonNull() {
-    final Single<SearchTaskResult> single = service.retrieveSearchResults("x:123123 y:456456");
+  @ParameterizedTest
+  @ValueSource(strings = {"x:123123 y:456456", "123123.0,456456.0", "123123,   456456.0", "123123   456456.0"})
+  void testCoordinateNonNull(final String query) {
+    final Single<SearchTaskResult> single = service.retrieveSearchResults(query);
     final SearchTaskResult result = single.blockingGet();
 
     assertEquals(2, result.getSuggestions().size(), "Result number should be 2");


### PR DESCRIPTION
Improved to allow plain floating numbers, like 1.0 2.0 as coordinates, either separated by a comma or not. This makes it easier when copy-paste points coordinates from Point geometries.