### PR TITLE
Fix search coordinates: Don't interpret single number as 2 coordinates

### DIFF
--- a/search-service-geo/src/main/java/nl/aerius/search/tasks/coordinate/AbstractCoordinateSearchService.java
+++ b/search-service-geo/src/main/java/nl/aerius/search/tasks/coordinate/AbstractCoordinateSearchService.java
@@ -39,7 +39,7 @@ public abstract class AbstractCoordinateSearchService implements SearchTaskServi
 
   // Regex used to identify a x:{x} y:{y} string
   private static final Pattern SEARCH_TERM_COORDINATE_REGEX = Pattern
-      .compile("(x:)?(\\d{1,6}\\.?\\d{1,6}?).\\s*(y:)?(\\d{1,6}\\.?\\d{1,6}?)", Pattern.CASE_INSENSITIVE);
+      .compile("(x:)?(\\d{1,6}\\.?\\d{1,6}?)\\s*[\\s,]\\s*(y:)?(\\d{1,6}\\.?\\d{1,6}?)", Pattern.CASE_INSENSITIVE);
 
   // The relevant groups in the above regular expression that identify the X and Y
   // coordinates respectively.

--- a/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/BNGCoordinateSearchServiceTest.java
+++ b/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/BNGCoordinateSearchServiceTest.java
@@ -74,9 +74,9 @@ class BNGCoordinateSearchServiceTest {
 
   @Test
   void testCoordinateNull() {
-    final Single<SearchTaskResult> single = service.retrieveSearchResults("nothing");
+    final Single<SearchTaskResult> single = service.retrieveSearchResults("4277497");
     final SearchTaskResult result = single.blockingGet();
 
-    assertEquals(0, result.getSuggestions().size(), "Result number should be 0");
+    assertEquals(0, result.getSuggestions().size(), "Result number should be 0: " + result.getSuggestions());
   }
 }

--- a/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/RDNewCoordinateSearchServiceTest.java
+++ b/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/RDNewCoordinateSearchServiceTest.java
@@ -39,7 +39,7 @@ class RDNewCoordinateSearchServiceTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"x:123123 y:456456", "123123.0,456456.0", "123123,   456456.0", "123123   456456.0"})
+  @ValueSource(strings = {"x:123123 y:456456", "123123.0,456456.0", "123123 456456.0", "123123,  456456.0", "123123  ,456456.0", "123123   456456.0"})
   void testCoordinateNonNull(final String query) {
     final Single<SearchTaskResult> single = service.retrieveSearchResults(query);
     final SearchTaskResult result = single.blockingGet();
@@ -77,9 +77,9 @@ class RDNewCoordinateSearchServiceTest {
 
   @Test
   void testCoordinateNull() {
-    final Single<SearchTaskResult> single = service.retrieveSearchResults("nothing");
+    final Single<SearchTaskResult> single = service.retrieveSearchResults("4277497");
     final SearchTaskResult result = single.blockingGet();
 
-    assertEquals(0, result.getSuggestions().size(), "Result number should be 0");
+    assertEquals(0, result.getSuggestions().size(), "Result number should be 0: " + result.getSuggestions());
   }
 }

--- a/search-service-mocks/src/main/java/nl/aerius/search/tasks/MockRuntimeExceptionTask.java
+++ b/search-service-mocks/src/main/java/nl/aerius/search/tasks/MockRuntimeExceptionTask.java
@@ -32,7 +32,7 @@ public class MockRuntimeExceptionTask implements SearchTaskService {
 
   @Override
   public Single<SearchTaskResult> retrieveSearchResults(final String query) {
-    LOG.debug("Mocking runtim exception for query [{}]", query);
+    LOG.debug("Mocking runtime exception for query [{}]", query);
     throw new NullPointerException("Some mocked nullpointer");
   }
 }

--- a/search-service/src/main/java/nl/aerius/search/tasks/TaskUtils.java
+++ b/search-service/src/main/java/nl/aerius/search/tasks/TaskUtils.java
@@ -52,20 +52,22 @@ public final class TaskUtils {
   public static Map<CapabilityKey, SearchTaskService> findTaskServices(final TaskFactory taskFactory, final Collection<CapabilityKey> capabilities,
       final Logger log) {
     return capabilities.stream()
-        .filter(v -> {
-          if (taskFactory.hasCapability(v)) {
-            return true;
-          } else {
-            log.error("No task for known capability: {}", v);
-            return false;
-          }
-        })
+        .filter(v -> checkCapcability(taskFactory, log, v))
         .collect(Collectors.toMap(v -> v, v -> taskFactory.getTask(v)))
         .entrySet().stream()
         .flatMap(e -> e.getValue().stream()
             .map(v -> new AbstractMap.SimpleImmutableEntry<CapabilityKey, SearchTaskService>(e.getKey(), v)))
         .collect(Collectors.toMap(SimpleImmutableEntry::getKey, SimpleImmutableEntry::getValue));
 
+  }
+
+  private static boolean checkCapcability(final TaskFactory taskFactory, final Logger log, final CapabilityKey v) {
+    if (taskFactory.hasCapability(v)) {
+      return true;
+    } else {
+      log.error("No task for known capability: {}", v);
+      return false;
+    }
   }
 
   public static Comparator<SearchSuggestion> getResultComparator() {

--- a/search-service/src/main/java/nl/aerius/search/tasks/async/SearchResult.java
+++ b/search-service/src/main/java/nl/aerius/search/tasks/async/SearchResult.java
@@ -50,6 +50,7 @@ public class SearchResult {
     if (LOG.isTraceEnabled()) {
       LOG.error("Search task {} has completed with a failure.", uuid);
     }
+    results.clear();
     results.add(SearchSuggestionBuilder.create("Failure during search, please contact the helpdesk"));
 
     complete = true;

--- a/search-service/src/test/java/nl/aerius/search/tasks/async/AsyncSearchTaskDelegatorTest.java
+++ b/search-service/src/test/java/nl/aerius/search/tasks/async/AsyncSearchTaskDelegatorTest.java
@@ -115,7 +115,8 @@ class AsyncSearchTaskDelegatorTest {
     factory.onFactoryConstructed();
     delegator = new AsyncSearchTaskDelegator(factory);
 
-    final Set<CapabilityKey> caps = Set.of(CapabilityKey.of(SearchCapability.MOCK_0, SearchRegion.NL),
+    final Set<CapabilityKey> caps = Set.of(
+        CapabilityKey.of(SearchCapability.MOCK_0, SearchRegion.NL),
         CapabilityKey.of(SearchCapability.MOCK_01, SearchRegion.NL),
         CapabilityKey.of(SearchCapability.MOCK_RUNTIME_EXCEPTION, SearchRegion.NL));
     final SearchResult result1 = delegator.retrieveSearchResultsAsync("test", caps);


### PR DESCRIPTION
Also fixed reporting error in Async call: when runtime exception clear all previous found results, and only return the error.