### PR TITLE
Snap Natura 2000 coordinates to fixed precision for cross-architecture determinism

### DIFF
--- a/search-service-n2000-assessment-areas-nl/src/main/java/nl/aerius/search/tasks/Natura2000WfsInterpreter.java
+++ b/search-service-n2000-assessment-areas-nl/src/main/java/nl/aerius/search/tasks/Natura2000WfsInterpreter.java
@@ -66,6 +66,8 @@ import kong.unirest.core.Unirest;
 public class Natura2000WfsInterpreter {
   private static final double DOUGLAS_PEUCKER_TOLERANCE = 5D;
   private static final int SRID_RDNEW = 28992;
+  // Snap coordinates to mm so reprojection stays deterministic across CPU architectures.
+  private static final double RD_NEW_PRECISION_SCALE = 1000D;
 
   private static final Logger LOG = LoggerFactory.getLogger(Natura2000WfsInterpreter.class);
 
@@ -82,7 +84,7 @@ public class Natura2000WfsInterpreter {
   // @formatter:on
 
   public Natura2000WfsInterpreter() {
-    this.rdNewGeometryFactory = new GeometryFactory(new PrecisionModel(), SRID_RDNEW);
+    this.rdNewGeometryFactory = new GeometryFactory(new PrecisionModel(RD_NEW_PRECISION_SCALE), SRID_RDNEW);
     this.wgsToRdNewtransform = createCRSTransform();
   }
 
@@ -231,7 +233,9 @@ public class Natura2000WfsInterpreter {
         final Coordinate coord = new Coordinate(Double.parseDouble(parts[i]), Double.parseDouble(parts[i + 1]));
 
         final Envelope env = extractEnvelope(coord, wgsToRdNewtransform);
-        coordinates[i / 2] = env.centre();
+        final Coordinate centre = env.centre();
+        rdNewGeometryFactory.getPrecisionModel().makePrecise(centre);
+        coordinates[i / 2] = centre;
       } catch (final NumberFormatException e) {
         LOG.info("Parsing: {} > {}", parts[i], parts[i + 1]);
       }

--- a/search-service-n2000-assessment-areas-nl/src/test/java/nl/aerius/search/tasks/Natura2000WfsInterpreterTest.java
+++ b/search-service-n2000-assessment-areas-nl/src/test/java/nl/aerius/search/tasks/Natura2000WfsInterpreterTest.java
@@ -52,11 +52,11 @@ class Natura2000WfsInterpreterTest {
 
     final Nature2000Area lepelaarplassen = mappedAreas.get("lepelaarplassen");
     assertArea(lepelaarplassen, "L_ff79e30b-f9d5-406b-94c0-7b3222ec4204", "Lepelaarplassen", "lepelaarplassen", "POLYGON ((",
-        "POINT (142831.32257141997 491155.1833244898)", 3564691);
+        "POINT (142831.323 491155.183)", 3564691);
 
     final Nature2000Area binnenveld = mappedAreas.get("binnenveld");
     assertArea(binnenveld, "L_7b89a66e-7f44-40f0-9d98-c7245f2c04c1", "Binnenveld", "binnenveld", "MULTIPOLYGON ((",
-        "POINT (168590.92165693894 446854.7658209189)", 1114151);
+        "POINT (168590.922 446854.766)", 1114151);
   }
 
   private void assertArea(final Nature2000Area naturea2000Area, final String id, final String name, final String normalizedName,


### PR DESCRIPTION
The EPSG:3035 to EPSG:28992 transform relies on Math trigonometry, which may differ by ~1 ULP between CPU architectures, making centroids non-reproducible. Snapping reprojected coordinates to a mm grid makes all downstream geometry deterministic.