### PR TITLE
Resolve SonarQube code smells

### DIFF
--- a/search-client/src/main/java/nl/aerius/search/wui/component/MapSearchComponent.java
+++ b/search-client/src/main/java/nl/aerius/search/wui/component/MapSearchComponent.java
@@ -104,7 +104,7 @@ public class MapSearchComponent implements IsVueComponent, HasCreated, HasMounte
       for (int i = 0; i < split.length; i++) {
         final String sample = split[i];
         if (sample.isEmpty()
-            || BOLD_CHARACTER.equals(sample.toLowerCase())) {
+            || BOLD_CHARACTER.equalsIgnoreCase(sample)) {
           continue;
         }
 

--- a/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/BingSearchService.java
+++ b/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/BingSearchService.java
@@ -103,15 +103,15 @@ public class BingSearchService implements SearchTaskService {
         .getJSONArray("value");
     // As the list of suggestions can contain duplicates when we translate them to actual locations, filter those out by using a set
     // Use a LinkedHashSet to keep the order.
-    final Set<SuggestedLocation> suggestedLocations = new LinkedHashSet<>();
+    final Set<BingSuggestedLocation> suggestedLocations = new LinkedHashSet<>();
     for (int i = 0; i < arr.length(); i++) {
       final JSONObject jsonObject = arr.getJSONObject(i);
-      final SuggestedLocation suggestedLocation = createSuggestedLocation(jsonObject);
+      final BingSuggestedLocation suggestedLocation = createSuggestedLocation(jsonObject);
       suggestedLocations.add(suggestedLocation);
     }
     // Now convert the suggestions by Bing to actual locations, to obtain geo information.
     int i = 0;
-    for (final SuggestedLocation suggestedLocation : suggestedLocations) {
+    for (final BingSuggestedLocation suggestedLocation : suggestedLocations) {
       final JSONObject jsonObject = obtainLocation(suggestedLocation);
       if (jsonObject != null) {
         final SearchSuggestion sug = createSuggestion(query, i, jsonObject);
@@ -143,19 +143,19 @@ public class BingSearchService implements SearchTaskService {
     throw new BingServiceException("Retries failed, last returned: " + body);
   }
 
-  private static SuggestedLocation createSuggestedLocation(final JSONObject jsonObject) {
+  private static BingSuggestedLocation createSuggestedLocation(final JSONObject jsonObject) {
     final JSONObject addressObject = jsonObject.getJSONObject("address");
-    return new SuggestedLocation(jsonObject.optString("name"),
+    return new BingSuggestedLocation(jsonObject.optString("name"),
         addressObject.optString("locality"),
         addressObject.optString("adminDistrict2"),
         addressObject.optString("addressLine"),
         addressObject.optString("formattedAddress"));
   }
 
-  private JSONObject obtainLocation(final SuggestedLocation location) {
+  private JSONObject obtainLocation(final BingSuggestedLocation location) {
     final String url;
-    if (location.name != null && !location.name.isEmpty()) {
-      url = String.format(BING_LOCATIONS_ENDPOINT, apiKey, "&query=" + location.name);
+    if (location.name() != null && !location.name().isEmpty()) {
+      url = String.format(BING_LOCATIONS_ENDPOINT, apiKey, "&query=" + location.name());
     } else {
       url = String.format(BING_LOCATIONS_ENDPOINT, apiKey, location.toAddressUrlParameters(REGION));
     }

--- a/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/BingSearchService.java
+++ b/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/BingSearchService.java
@@ -20,10 +20,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +47,9 @@ import kong.unirest.core.json.JSONObject;
 @Component
 @ImplementsCapability(value = SearchCapability.BASIC_INFO, region = SearchRegion.UK)
 public class BingSearchService implements SearchTaskService {
+  private static final int HTTP_STATUS_OK = 200;
+  private static final int HTTP_STATUS_TOO_MANY_REQUESTS = 429;
+
   private static final String REGION = "GB";
   private static final String CULTURE = "en-GB";
   private static final String BNG_BOUNDS = "49.79,-8.82,60.94,1.92";
@@ -122,14 +123,13 @@ public class BingSearchService implements SearchTaskService {
 
   private JSONArray obtainResources(final String url) {
     JSONObject body = null;
-    int retry = 0;
-    while (retry++ < maxRetries) {
+    for (int retry = 1; retry <= maxRetries; retry++) {
       final HttpResponse<JsonNode> json = Unirest.get(url).asJson();
       body = json.getBody().getObject();
       final int statusCode = body.getInt("statusCode");
-      if (statusCode == 200) {
+      if (statusCode == HTTP_STATUS_OK) {
         return body.getJSONArray("resourceSets").getJSONObject(0).getJSONArray("resources");
-      } else if (statusCode == 429) {
+      } else if (statusCode == HTTP_STATUS_TOO_MANY_REQUESTS) {
         LOG.info("Got too many retries status code from Bing, attempt {}.", retry);
         try {
           TimeUnit.SECONDS.sleep(1);
@@ -143,7 +143,7 @@ public class BingSearchService implements SearchTaskService {
     throw new BingServiceException("Retries failed, last returned: " + body);
   }
 
-  private SuggestedLocation createSuggestedLocation(final JSONObject jsonObject) {
+  private static SuggestedLocation createSuggestedLocation(final JSONObject jsonObject) {
     final JSONObject addressObject = jsonObject.getJSONObject("address");
     return new SuggestedLocation(jsonObject.optString("name"),
         addressObject.optString("locality"),
@@ -157,7 +157,7 @@ public class BingSearchService implements SearchTaskService {
     if (location.name != null && !location.name.isEmpty()) {
       url = String.format(BING_LOCATIONS_ENDPOINT, apiKey, "&query=" + location.name);
     } else {
-      url = String.format(BING_LOCATIONS_ENDPOINT, apiKey, location.toAddressUrlParameters());
+      url = String.format(BING_LOCATIONS_ENDPOINT, apiKey, location.toAddressUrlParameters(REGION));
     }
     final JSONArray arr = obtainResources(url);
     return arr.length() == 0 ? null : arr.getJSONObject(0);
@@ -219,63 +219,5 @@ public class BingSearchService implements SearchTaskService {
     }
 
     return suggestionType;
-  }
-
-  private static class SuggestedLocation {
-
-    private final String name;
-    private final String locality;
-    private final String adminDistrict;
-    private final String addressLine;
-    private final String formattedAddress;
-
-    SuggestedLocation(final String name, final String locality, final String adminDistrict, final String addressLine, final String formattedAddress) {
-      this.name = name;
-      this.locality = locality;
-      this.adminDistrict = adminDistrict;
-      this.addressLine = addressLine;
-      this.formattedAddress = formattedAddress;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(addressLine, adminDistrict, formattedAddress, locality, name);
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-      if (this == obj)
-        return true;
-      if (obj == null)
-        return false;
-      if (getClass() != obj.getClass())
-        return false;
-      final SuggestedLocation other = (SuggestedLocation) obj;
-      return Objects.equals(addressLine, other.addressLine) && Objects.equals(adminDistrict, other.adminDistrict)
-          && Objects.equals(formattedAddress, other.formattedAddress) && Objects.equals(locality, other.locality)
-          && Objects.equals(name, other.name);
-    }
-
-    String toAddressUrlParameters() {
-      final Map<String, String> parameters = new HashMap<>();
-      parameters.put("countryRegion", REGION);
-      if (locality != null) {
-        parameters.put("locality", locality);
-      }
-      if (adminDistrict != null) {
-        parameters.put("adminDistrict", adminDistrict);
-      }
-      if (addressLine != null) {
-        parameters.put("addressLine", addressLine);
-      }
-      if (formattedAddress != null) {
-        parameters.put("query", formattedAddress);
-      }
-      return parameters.isEmpty()
-          ? ""
-          : "&" + parameters.entrySet().stream()
-              .map(e -> e.getKey() + "=" + e.getValue())
-              .collect(Collectors.joining("&"));
-    }
   }
 }

--- a/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/BingSuggestedLocation.java
+++ b/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/BingSuggestedLocation.java
@@ -18,46 +18,12 @@ package nl.aerius.search.tasks;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
  * A location suggested by the Bing autosuggest endpoint, to be translated into an actual location.
  */
-final class SuggestedLocation {
-  final String name;
-  private final String locality;
-  private final String adminDistrict;
-  private final String addressLine;
-  private final String formattedAddress;
-
-  SuggestedLocation(final String name, final String locality, final String adminDistrict, final String addressLine, final String formattedAddress) {
-    this.name = name;
-    this.locality = locality;
-    this.adminDistrict = adminDistrict;
-    this.addressLine = addressLine;
-    this.formattedAddress = formattedAddress;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(addressLine, adminDistrict, formattedAddress, locality, name);
-  }
-
-  @Override
-  public boolean equals(final Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null || getClass() != obj.getClass()) {
-      return false;
-    }
-    final SuggestedLocation other = (SuggestedLocation) obj;
-    return Objects.equals(addressLine, other.addressLine) && Objects.equals(adminDistrict, other.adminDistrict)
-        && Objects.equals(formattedAddress, other.formattedAddress) && Objects.equals(locality, other.locality)
-        && Objects.equals(name, other.name);
-  }
-
+record BingSuggestedLocation(String name, String locality, String adminDistrict, String addressLine, String formattedAddress) {
   String toAddressUrlParameters(final String countryRegion) {
     final Map<String, String> parameters = new HashMap<>();
     parameters.put("countryRegion", countryRegion);

--- a/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/SuggestedLocation.java
+++ b/search-service-bing-geocoder/src/main/java/nl/aerius/search/tasks/SuggestedLocation.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.search.tasks;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * A location suggested by the Bing autosuggest endpoint, to be translated into an actual location.
+ */
+final class SuggestedLocation {
+  final String name;
+  private final String locality;
+  private final String adminDistrict;
+  private final String addressLine;
+  private final String formattedAddress;
+
+  SuggestedLocation(final String name, final String locality, final String adminDistrict, final String addressLine, final String formattedAddress) {
+    this.name = name;
+    this.locality = locality;
+    this.adminDistrict = adminDistrict;
+    this.addressLine = addressLine;
+    this.formattedAddress = formattedAddress;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(addressLine, adminDistrict, formattedAddress, locality, name);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    final SuggestedLocation other = (SuggestedLocation) obj;
+    return Objects.equals(addressLine, other.addressLine) && Objects.equals(adminDistrict, other.adminDistrict)
+        && Objects.equals(formattedAddress, other.formattedAddress) && Objects.equals(locality, other.locality)
+        && Objects.equals(name, other.name);
+  }
+
+  String toAddressUrlParameters(final String countryRegion) {
+    final Map<String, String> parameters = new HashMap<>();
+    parameters.put("countryRegion", countryRegion);
+    if (locality != null) {
+      parameters.put("locality", locality);
+    }
+    if (adminDistrict != null) {
+      parameters.put("adminDistrict", adminDistrict);
+    }
+    if (addressLine != null) {
+      parameters.put("addressLine", addressLine);
+    }
+    if (formattedAddress != null) {
+      parameters.put("query", formattedAddress);
+    }
+    return parameters.isEmpty()
+        ? ""
+        : ("&" + parameters.entrySet().stream()
+            .map(e -> e.getKey() + "=" + e.getValue())
+            .collect(Collectors.joining("&")));
+  }
+}

--- a/search-service-geo/src/main/java/nl/aerius/search/tasks/coordinate/AbstractCoordinateSearchService.java
+++ b/search-service-geo/src/main/java/nl/aerius/search/tasks/coordinate/AbstractCoordinateSearchService.java
@@ -39,7 +39,7 @@ public abstract class AbstractCoordinateSearchService implements SearchTaskServi
 
   // Regex used to identify a x:{x} y:{y} string
   private static final Pattern SEARCH_TERM_COORDINATE_REGEX = Pattern
-      .compile("(x:)?(\\d{1,6}\\.?\\d{1,6}?)\\s*[\\s,]\\s*(y:)?(\\d{1,6}\\.?\\d{1,6}?)", Pattern.CASE_INSENSITIVE);
+      .compile("(x:)?([0-9]{1,6}\\.?[0-9]{1,6})\\s*[\\s,]\\s*(y:)?([0-9]{1,6}\\.?[0-9]{1,6})", Pattern.CASE_INSENSITIVE);
 
   // The relevant groups in the above regular expression that identify the X and Y
   // coordinates respectively.

--- a/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/BNGCoordinateSearchServiceTest.java
+++ b/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/BNGCoordinateSearchServiceTest.java
@@ -54,22 +54,22 @@ class BNGCoordinateSearchServiceTest {
     final SearchSuggestion coordinateSuggestion = result.getSuggestions().stream()
         .filter(v -> v.getType() == SearchSuggestionType.COORDINATE)
         .findFirst().orElseThrow();
-    assertEquals("x:123123 y:456456", coordinateSuggestion.getDescription());
-    assertEquals("POINT(123123 456456)", coordinateSuggestion.getCentroid());
-    assertNull(coordinateSuggestion.getGeometry());
-    assertNull(coordinateSuggestion.getBbox());
-    assertEquals(100.0, coordinateSuggestion.getScore());
+    assertEquals("x:123123 y:456456", coordinateSuggestion.getDescription(), "Coordinate description should match the query");
+    assertEquals("POINT(123123 456456)", coordinateSuggestion.getCentroid(), "Coordinate centroid should match the query");
+    assertNull(coordinateSuggestion.getGeometry(), "Coordinate suggestion should have no geometry");
+    assertNull(coordinateSuggestion.getBbox(), "Coordinate suggestion should have no bbox");
+    assertEquals(100.0, coordinateSuggestion.getScore(), "Coordinate match should score 100");
 
     final SearchSuggestion receptorSuggestion = result.getSuggestions().stream()
         .filter(v -> v.getType() == SearchSuggestionType.RECEPTOR)
         .findFirst().orElseThrow();
-    assertEquals("Receptor 7516977 - x:123121 y:456501", receptorSuggestion.getDescription());
-    assertEquals("POINT(123120.62375334681 456501.39829089347)", receptorSuggestion.getCentroid());
+    assertEquals("Receptor 7516977 - x:123121 y:456501", receptorSuggestion.getDescription(), "Receptor description should match the nearest receptor");
+    assertEquals("POINT(123120.62375334681 456501.39829089347)", receptorSuggestion.getCentroid(), "Receptor centroid should match the nearest receptor");
     assertEquals(
         "POLYGON((123183.0 456609.0,123245.0 456501.0,123183.0 456394.0,123059.0 456394.0,122997.0 456501.0,123059.0 456609.0,123183.0 456609.0))",
-        receptorSuggestion.getGeometry());
-    assertNull(receptorSuggestion.getBbox());
-    assertEquals(100.0, receptorSuggestion.getScore());
+        receptorSuggestion.getGeometry(), "Receptor geometry should be the receptor hexagon");
+    assertNull(receptorSuggestion.getBbox(), "Receptor suggestion should have no bbox");
+    assertEquals(100.0, receptorSuggestion.getScore(), "Receptor match should score 100");
   }
 
   @Test

--- a/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/BNGCoordinateSearchServiceTest.java
+++ b/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/BNGCoordinateSearchServiceTest.java
@@ -45,7 +45,7 @@ class BNGCoordinateSearchServiceTest {
     assertEquals(1, result.getSuggestions().stream()
         .map(SearchSuggestion::getType)
         .filter(v -> v == SearchSuggestionType.COORDINATE)
-        .count(), "Expecting 1 receptor result.");
+        .count(), "Expecting 1 coordinate result.");
     assertEquals(1, result.getSuggestions().stream()
         .map(SearchSuggestion::getType)
         .filter(v -> v == SearchSuggestionType.RECEPTOR)

--- a/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/RDNewCoordinateSearchServiceTest.java
+++ b/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/RDNewCoordinateSearchServiceTest.java
@@ -57,22 +57,22 @@ class RDNewCoordinateSearchServiceTest {
     final SearchSuggestion coordinateSuggestion = result.getSuggestions().stream()
         .filter(v -> v.getType() == SearchSuggestionType.COORDINATE)
         .findFirst().orElseThrow();
-    assertEquals("x:123123 y:456456", coordinateSuggestion.getDescription());
-    assertEquals("POINT(123123 456456)", coordinateSuggestion.getCentroid());
-    assertNull(coordinateSuggestion.getGeometry());
-    assertNull(coordinateSuggestion.getBbox());
-    assertEquals(100.0, coordinateSuggestion.getScore());
+    assertEquals("x:123123 y:456456", coordinateSuggestion.getDescription(), "Coordinate description should match the query");
+    assertEquals("POINT(123123 456456)", coordinateSuggestion.getCentroid(), "Coordinate centroid should match the query");
+    assertNull(coordinateSuggestion.getGeometry(), "Coordinate suggestion should have no geometry");
+    assertNull(coordinateSuggestion.getBbox(), "Coordinate suggestion should have no bbox");
+    assertEquals(100.0, coordinateSuggestion.getScore(), "Coordinate match should score 100");
 
     final SearchSuggestion receptorSuggestion = result.getSuggestions().stream()
         .filter(v -> v.getType() == SearchSuggestionType.RECEPTOR)
         .findFirst().orElseThrow();
-    assertEquals("Receptor 4544831 - x:123094 y:456481", receptorSuggestion.getDescription());
-    assertEquals("POINT(123093.6639087096 456481.09186897834)", receptorSuggestion.getCentroid());
+    assertEquals("Receptor 4544831 - x:123094 y:456481", receptorSuggestion.getDescription(), "Receptor description should match the nearest receptor");
+    assertEquals("POINT(123093.6639087096 456481.09186897834)", receptorSuggestion.getCentroid(), "Receptor centroid should match the nearest receptor");
     assertEquals(
         "POLYGON((123125.0 456535.0,123156.0 456481.0,123125.0 456427.0,123063.0 456427.0,123032.0 456481.0,123063.0 456535.0,123125.0 456535.0))",
-        receptorSuggestion.getGeometry());
-    assertNull(receptorSuggestion.getBbox());
-    assertEquals(100.0, receptorSuggestion.getScore());
+        receptorSuggestion.getGeometry(), "Receptor geometry should be the receptor hexagon");
+    assertNull(receptorSuggestion.getBbox(), "Receptor suggestion should have no bbox");
+    assertEquals(100.0, receptorSuggestion.getScore(), "Receptor match should score 100");
   }
 
   @Test

--- a/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/RDNewCoordinateSearchServiceTest.java
+++ b/search-service-geo/src/test/java/nl/aerius/search/tasks/coordinate/RDNewCoordinateSearchServiceTest.java
@@ -48,7 +48,7 @@ class RDNewCoordinateSearchServiceTest {
     assertEquals(1, result.getSuggestions().stream()
         .map(SearchSuggestion::getType)
         .filter(v -> v == SearchSuggestionType.COORDINATE)
-        .count(), "Expecting 1 receptor result.");
+        .count(), "Expecting 1 coordinate result.");
     assertEquals(1, result.getSuggestions().stream()
         .map(SearchSuggestion::getType)
         .filter(v -> v == SearchSuggestionType.RECEPTOR)

--- a/search-service-geo/src/test/java/nl/aerius/search/tasks/receptor/BNGReceptorSearchServiceTest.java
+++ b/search-service-geo/src/test/java/nl/aerius/search/tasks/receptor/BNGReceptorSearchServiceTest.java
@@ -43,13 +43,13 @@ class BNGReceptorSearchServiceTest {
 
     assertEquals(1, result.getSuggestions().size(), "Result number should be 1");
     final SearchSuggestion suggestion = result.getSuggestions().get(0);
-    assertEquals(SearchSuggestionType.RECEPTOR, suggestion.getType());
-    assertEquals("Receptor 123123 - x:644445 y:11307", suggestion.getDescription());
-    assertEquals("POINT(644445.465822343 11307.075536400083)", suggestion.getCentroid());
+    assertEquals(SearchSuggestionType.RECEPTOR, suggestion.getType(), "Suggestion type should be receptor");
+    assertEquals("Receptor 123123 - x:644445 y:11307", suggestion.getDescription(), "Description should match the receptor");
+    assertEquals("POINT(644445.465822343 11307.075536400083)", suggestion.getCentroid(), "Centroid should match the receptor location");
     assertEquals("POLYGON((644508.0 11415.0,644570.0 11307.0,644508.0 11200.0,644383.0 11200.0,644321.0 11307.0,644383.0 11415.0,644508.0 11415.0))",
-        suggestion.getGeometry());
-    assertNull(suggestion.getBbox());
-    assertEquals(100.0, suggestion.getScore());
+        suggestion.getGeometry(), "Geometry should be the receptor hexagon");
+    assertNull(suggestion.getBbox(), "Receptor suggestion should have no bbox");
+    assertEquals(100.0, suggestion.getScore(), "Receptor match should score 100");
   }
 
   @Test

--- a/search-service-geo/src/test/java/nl/aerius/search/tasks/receptor/RDNewReceptorSearchServiceTest.java
+++ b/search-service-geo/src/test/java/nl/aerius/search/tasks/receptor/RDNewReceptorSearchServiceTest.java
@@ -43,13 +43,13 @@ class RDNewReceptorSearchServiceTest {
 
     assertEquals(1, result.getSuggestions().size(), "Result number should be 1");
     final SearchSuggestion suggestion = result.getSuggestions().get(0);
-    assertEquals(SearchSuggestionType.RECEPTOR, suggestion.getType());
-    assertEquals("Receptor 123123 - x:152873 y:301098", suggestion.getDescription());
-    assertEquals("POINT(152873.01939997677 301098.27972729417)", suggestion.getCentroid());
+    assertEquals(SearchSuggestionType.RECEPTOR, suggestion.getType(), "Suggestion type should be receptor");
+    assertEquals("Receptor 123123 - x:152873 y:301098", suggestion.getDescription(), "Description should match the receptor");
+    assertEquals("POINT(152873.01939997677 301098.27972729417)", suggestion.getCentroid(), "Centroid should match the receptor location");
     assertEquals("POLYGON((152904.0 301152.0,152935.0 301098.0,152904.0 301045.0,152842.0 301045.0,152811.0 301098.0,152842.0 301152.0,152904.0 301152.0))",
-        suggestion.getGeometry());
-    assertNull(suggestion.getBbox());
-    assertEquals(100.0, suggestion.getScore());
+        suggestion.getGeometry(), "Geometry should be the receptor hexagon");
+    assertNull(suggestion.getBbox(), "Receptor suggestion should have no bbox");
+    assertEquals(100.0, suggestion.getScore(), "Receptor match should score 100");
   }
 
   @Test

--- a/search-service/src/main/java/nl/aerius/search/controller/SearchViewController.java
+++ b/search-service/src/main/java/nl/aerius/search/controller/SearchViewController.java
@@ -19,7 +19,6 @@ package nl.aerius.search.controller;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,7 +33,11 @@ import nl.aerius.search.tasks.sync.BlockingSearchTaskDelegator;
  */
 @Controller
 public class SearchViewController {
-  @Autowired BlockingSearchTaskDelegator delegator;
+  private final BlockingSearchTaskDelegator delegator;
+
+  public SearchViewController(final BlockingSearchTaskDelegator delegator) {
+    this.delegator = delegator;
+  }
 
   @GetMapping(value = { "/" })
   public String searchForm(final Model model) {

--- a/search-service/src/main/java/nl/aerius/search/domain/collections/CacheMap.java
+++ b/search-service/src/main/java/nl/aerius/search/domain/collections/CacheMap.java
@@ -93,7 +93,7 @@ public class CacheMap<K, V> extends HashMap<K, V> {
     this.timeToLive = timeToLive;
     this.logger = logger;
 
-    scheduler.scheduleAtFixedRate(() -> doSweep(), interval, interval, TimeUnit.SECONDS);
+    scheduler.scheduleAtFixedRate(this::doSweep, interval, interval, TimeUnit.SECONDS);
   }
 
   @Override

--- a/search-service/src/main/java/nl/aerius/search/rest/SearchRestService.java
+++ b/search-service/src/main/java/nl/aerius/search/rest/SearchRestService.java
@@ -17,7 +17,6 @@
 package nl.aerius.search.rest;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,8 +63,10 @@ public class SearchRestService {
   @RequestMapping(value = "/api/search-async", method = { RequestMethod.GET, RequestMethod.POST })
   public SearchResult retrieveSearchResultsAsync(final String query,
       @RequestParam(defaultValue = DEFAULT_CAPABILITIES) final List<String> capabilities,
-      @RequestParam(defaultValue = DEFAULT_REGION) final String region, final Optional<String> cancel) {
-    cancel.ifPresent(uuid -> taskDelegator.cancelSearchTask(uuid));
+      @RequestParam(defaultValue = DEFAULT_REGION) final String region, @RequestParam(required = false) final String cancel) {
+    if (cancel != null) {
+      taskDelegator.cancelSearchTask(cancel);
+    }
 
     return taskDelegator.retrieveSearchResultsAsync(scrub(query), TaskUtils.parseCapabilities(capabilities, region));
   }


### PR DESCRIPTION
Tier 1/2 cleanups: extract Bing SuggestedLocation to its own class (braces, parentheses, magic numbers, increment, static factory), drop Optional REST parameter, equalsIgnoreCase in MapSearchComponent, redundant initialisers in SearchContext, method reference in CacheMap, ASCII-explicit coordinate regex, and assertion messages across the geo tests.