### PR TITLE
[github-actions] Use new init function

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -8,14 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out github-actions repo
-        uses: actions/checkout@v4
-        with:
-          repository: aerius/github-actions
-          path: aerius-github-actions
-          ref: v1.1
+      - name: Init the github-actions repo
+        uses: aerius/github-actions/init@v1.1
 
-      - uses: aerius/github-actions/events/push-event-action@v1.1
+      - uses: ./aerius-github-actions/events/push-event-action
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}

--- a/.github/workflows/on-release-published.yml
+++ b/.github/workflows/on-release-published.yml
@@ -9,14 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out github-actions repo
-        uses: actions/checkout@v4
-        with:
-          repository: aerius/github-actions
-          path: aerius-github-actions
-          ref: v1.1
+      - name: Init the github-actions repo
+        uses: aerius/github-actions/init@v1.1
 
-      - uses: aerius/github-actions/events/release-event-action@v1.1
+      - uses: ./aerius-github-actions/events/release-event-action
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}


### PR DESCRIPTION
Gets rid of the custom checkout that we need to keep updated and optionally multiple references to the version of (aerius-)github-actions.