### PR TITLE
Bump gwt-client-common to pick up vue-gwt scoped-CSS fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 
   <properties>
     <imaer.version>6.0.1-2</imaer.version>
-    <aerius.gwt-client-common.version>1.9.0</aerius.gwt-client-common.version>
+    <aerius.gwt-client-common.version>1.12.0-SNAPSHOT</aerius.gwt-client-common.version>
     <!-- Not updating JTS to 1.20.0 due to change in coordinates (rounding) -->
     <jts.version>1.19.0</jts.version>
     <unirest-java.version>4.4.5</unirest-java.version>


### PR DESCRIPTION
---
<details>
<summary>LLM-generated technical summary</summary>

search-client pinned gwt-client-common 1.9.0, which predates the vue-gwt fork fix
(aerius/vue-gwt#9) that moved scoped-CSS injection out of the generated factory's
static get() accessor and into the shared init() method. search-client's Vue
components are wired into consuming apps via Gin/DI, which calls init() directly
and never touches get() - so their scoped CSS was never injected, and search
results rendered unstyled. 1.12.0-SNAPSHOT is the same not-yet-released version
calculator already points at to get this fix; this pin should move to a stable
release once gwt-client-common's own version bump (aerius/gwt-client-common#79)
ships.
</details>
